### PR TITLE
add support for cargo-binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,7 @@ twox-hash = { version = "2.1.1", features = ["serialize"] }
 [profile.bench]
 debug = true
 strip = false
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/miro-pdf{binary-ext}"
+pkg-fmt = "bin"


### PR DESCRIPTION
Should fix it since this works:
```sh
cargo-binstall --pkg-url="{ repo }/releases/download/v{ version }/miro-pdf{ binary-ext }" --pkg-fmt="bin" miro-pdf
```