### PR TITLE
fix: empty check when handling messages with no PDF loaded

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -221,9 +221,15 @@ impl App {
                 println!("[DEBUG] {s}");
                 iced::Task::none()
             }
-            AppMessage::PdfMessage(msg) => self.pdfs[self.pdf_idx]
-                .update(msg)
-                .map(AppMessage::PdfMessage),
+            AppMessage::PdfMessage(msg) => {
+                if !self.pdfs.is_empty() {
+                    self.pdfs[self.pdf_idx]
+                        .update(msg)
+                        .map(AppMessage::PdfMessage)
+                } else {
+                    iced::Task::none()
+                }
+            }
             AppMessage::OpenNewFileFinder => iced::Task::perform(
                 async {
                     AsyncFileDialog::new()
@@ -268,7 +274,9 @@ impl App {
                 iced::Task::none()
             }
             AppMessage::NextTab => {
-                self.pdf_idx = (self.pdf_idx + 1).min(self.pdfs.len() - 1);
+                if !self.pdfs.is_empty() {
+                    self.pdf_idx = (self.pdf_idx + 1).min(self.pdfs.len() - 1);
+                }
                 iced::Task::none()
             }
             AppMessage::OpenTab(i) => {
@@ -476,7 +484,8 @@ impl App {
             AppMessage::Scroll(delta) => {
                 if !self.pdfs.is_empty() {
                     let button = match delta {
-                        iced::mouse::ScrollDelta::Lines { y, .. } | iced::mouse::ScrollDelta::Pixels { y, .. } => {
+                        iced::mouse::ScrollDelta::Lines { y, .. }
+                        | iced::mouse::ScrollDelta::Pixels { y, .. } => {
                             if y > 0.0 {
                                 MouseButton::ScrollUp
                             } else if y < 0.0 {
@@ -487,7 +496,8 @@ impl App {
                         }
                     };
                     if let Some(action) = self.get_mouse_action(button) {
-                        let _ = self.pdfs[self.pdf_idx].update(PdfMessage::MouseAction(action, true));
+                        let _ =
+                            self.pdfs[self.pdf_idx].update(PdfMessage::MouseAction(action, true));
                     }
                 }
                 iced::Task::none()


### PR DESCRIPTION
Fixed two index out of bounds panics that occurred when the pdfs vector is empty:

1. PdfMessage handler (line 224): Add empty check before accessing self.pdfs[self.pdf_idx] to prevent panic when PDF-related messages (e.g., Print, Zoom from menu) are triggered without a document loaded

2. NextTab handler (line 276): Add empty check to prevent integer underflow when calculating (self.pdfs.len() - 1) with an empty vector

Both handlers now return Task::none() when no PDFs are loaded, matching the pattern used by other message handlers in the codebase.

For reference, here is what I was seeing when trying to open miro with no file. Similar error message to https://github.com/vincent-uden/miro/issues/49#issuecomment-3410166967
```
thread 'main' panicked at src/app.rs:224:53:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'main' panicked at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iced_winit-0.13.0/src/program.rs:464:43:
Send event: SendError { kind: Disconnected }

thread 'main' panicked at library/core/src/panicking.rs:225:5:
panic in a function that cannot unwind
stack backtrace:  0:        0x10252c554 - std::backtrace_rs::backtrace::libunwind::trace::h72f4b72e0962905d
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1:        0x10252c554 - std::backtrace_rs::backtrace::trace_unsynchronized::hff394536698b6b10
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2:        0x10252c554 - std::sys::backtrace::_print_fmt::h64d1e3035850353e
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:66:9
   3:        0x10252c554 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::hf35f9734f9a29483
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:39:26
   4:        0x10254ca70 - core::fmt::rt::Argument::fmt::hedf6f2a66f855f69
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/fmt/rt.rs:173:76
   5:        0x10254ca70 - core::fmt::write::h60ec6633daab7b35
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/fmt/mod.rs:1468:25
   6:        0x10252961c - std::io::default_write_fmt::h0e30d7b1295222cb
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/io/mod.rs:639:11
   7:        0x10252961c - std::io::Write::write_fmt::hc29709fdab2e34e2
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/io/mod.rs:1954:13
   8:        0x10252c408 - std::sys::backtrace::BacktraceLock::print::hca95bffd78053951
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:42:9
   9:        0x10252d6cc - std::panicking::default_hook::{{closure}}::h357ed4fbef22679d
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:300:27
  10:        0x10252d524 - std::panicking::default_hook::h0a4e133b151d5758
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:327:9
  11:        0x10252e16c - std::panicking::rust_panic_with_hook::h557a23724a5de839
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:833:13
  12:        0x10252dd60 - std::panicking::begin_panic_handler::{{closure}}::h269cace6208fef05
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:699:13
  13:        0x10252ca04 - std::sys::backtrace::__rust_end_short_backtrace::h5be0da278f3aaec7
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:174:18
  14:        0x10252da64 - __rustc[de2ca18b4c54d5b8]::rust_begin_unwind
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5
  15:        0x1025a1e98 - core::panicking::panic_nounwind_fmt::runtime::h5c6a5149472cea01
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:117:22
  16:        0x1025a1e98 - core::panicking::panic_nounwind_fmt::h9825e2aa83719df7
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/intrinsics/mod.rs:2367:9
  17:        0x1025a1f10 - core::panicking::panic_nounwind::h4cc28a4411926d9d
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:225:5
  18:        0x1025a20c4 - core::panicking::panic_cannot_unwind::ha4e3ecab6cb0371c
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:346:5
  19:        0x10149fa7c - <Closure as block2::traits::IntoBlock<(),R>>::__get_invoke_stack_block::invoke::he7b546f282ce0872
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/block2-0.5.1/src/traits.rs:103:17
  20:        0x1820e76e4 - <unknown>
  21:        0x1820e7624 - <unknown>
  22:        0x1820e6a68 - <unknown>
  23:        0x1821a4898 - <unknown>
  24:        0x18eae3730 - <unknown>
  25:        0x18eae69d0 - <unknown>
  26:        0x18ec701f4 - <unknown>
  27:        0x1869be25c - <unknown>
  28:        0x1864d4edc - <unknown>
  29:        0x186f27958 - <unknown>
  30:        0x186f27664 - <unknown>
  31:        0x1864cd720 - <unknown>
  32:        0x101547e84 - <() as objc2::encode::EncodeArguments>::__invoke::h86dc16942b212fc0
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-0.5.2/src/encode.rs:437:26
  33:        0x10154a650 - objc2::runtime::message_receiver::msg_send_primitive::send::h7aba5b108e7bebc4
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-0.5.2/src/runtime/message_receiver.rs:173:18
  34:        0x101541fd8 - objc2::runtime::message_receiver::MessageReceiver::send_message::h532a2f9a47f5f6f5
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-0.5.2/src/runtime/message_receiver.rs:433:38
  35:        0x1014c1158 - objc2::__macro_helpers::msg_send::MsgSend::send_message::h8516777e9cf42b70
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-0.5.2/src/__macro_helpers/msg_send.rs:27:31
  36:        0x1014c1a0c - objc2_app_kit::generated::__NSApplication::NSApplication::run::hb7276058bacdbcf5
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-0.5.2/src/macros/extern_methods.rs:247:14
  37:        0x100a583f8 - winit::platform_impl::macos::event_loop::EventLoop<T>::run_on_demand::{{closure}}::{{closure}}::hc783cb42f7937e65
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.9/src/platform_impl/macos/event_loop.rs:303:35
  38:        0x100b91ef8 - objc2::rc::autorelease::autoreleasepool::hbaa87d53a9c68619
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-0.5.2/src/rc/autorelease.rs:438:15
  39:        0x100a5834c - winit::platform_impl::macos::event_loop::EventLoop<T>::run_on_demand::{{closure}}::h0b8c42a9ab96d41b
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.9/src/platform_impl/macos/event_loop.rs:289:13
  40:        0x100bd6e68 - winit::platform_impl::macos::event_handler::EventHandler::set::h2b4b5174c447eb30
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.9/src/platform_impl/macos/event_handler.rs:98:9
  41:        0x100b61dcc - winit::platform_impl::macos::app_state::ApplicationDelegate::set_event_handler::hd9ec6d669c569a6a
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.9/src/platform_impl/macos/app_state.rs:191:36
  42:        0x100a582e4 - winit::platform_impl::macos::event_loop::EventLoop<T>::run_on_demand::h1e6a1ab7f32c2de4
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.9/src/platform_impl/macos/event_loop.rs:288:23
  43:        0x100a588d8 - winit::platform_impl::macos::event_loop::EventLoop<T>::run::h129a283b00b501b6
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.9/src/platform_impl/macos/event_loop.rs:275:14
  44:        0x100b2ac00 - winit::event_loop::EventLoop<T>::run_app::hb454a32b24fe0409
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.9/src/event_loop.rs:265:25
  45:        0x100b7e7a8 - iced_winit::program::run::h112f4fe1b1817015
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iced_winit-0.13.0/src/program.rs:605:28
  46:        0x100bd69a8 - iced::program::Program::run_with::hc39a6c6d094f1e62
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iced-0.13.1/src/program.rs:177:12
  47:        0x100b6dc60 - iced::application::Application<P>::run_with::hd85b658dea13fdf7
                               at /Users/vinay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iced-0.13.1/src/application.rs:177:14
  48:        0x100a9078c - miro_pdf::main::h46c3cbe24e699081
                               at /Users/vinay/v/code/proj/rust/miro/src/main.rs:74:10
  49:        0x100a1b03c - core::ops::function::FnOnce::call_once::h548b479528b086b2
                               at /Users/vinay/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:253:5
  50:        0x100a01914 - std::sys::backtrace::__rust_begin_short_backtrace::h4d6e320197bb4052
                               at /Users/vinay/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:158:18
  51:        0x100b8c238 - std::rt::lang_start::{{closure}}::hff3ac093d7b85b25
                               at /Users/vinay/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:206:18
  52:        0x102522588 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::hbb2eb0e6976088d9
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/ops/function.rs:290:21
  53:        0x102522588 - std::panicking::catch_unwind::do_call::h93858ce5ba09f3d9
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40
  54:        0x102522588 - std::panicking::catch_unwind::h129a241a010f1b76
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19
  55:        0x102522588 - std::panic::catch_unwind::h5ca6b885cfe10586
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14
  56:        0x102522588 - std::rt::lang_start_internal::{{closure}}::hed6353a412388a00
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:175:24
  57:        0x102522588 - std::panicking::catch_unwind::do_call::h6579b7caa3691f01
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40
  58:        0x102522588 - std::panicking::catch_unwind::h4557f88752b89087
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19
  59:        0x102522588 - std::panic::catch_unwind::h82809ba82b8374af
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14
  60:        0x102522588 - std::rt::lang_start_internal::hdb28e94b6865fa11
                               at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:171:5
  61:        0x100b8c208 - std::rt::lang_start::h498ed21a11401e96
                               at /Users/vinay/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:205:5
  62:        0x100a9113c - _main
thread caused non-unwinding panic. aborting.
```