### PR TITLE
Prevent the terminal from opening on Windows in release builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use std::{
     fs, io,
     path::PathBuf,


### PR DESCRIPTION
Disable the terminal window in release builds. Debug builds will remain as they were.

Resolves #68.