### PR TITLE
add ScaleFactor setting to readme and default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Set <setting> <value>
 Available settings:
 - `Rpc <True|False>` - Enable/disable RPC server
 - `RpcPort <number>` - Set RPC server port
+- `ScaleFactor <number>` - Set scale factor
 
 #### Error Handling
 

--- a/assets/default.conf
+++ b/assets/default.conf
@@ -46,3 +46,6 @@ MouseBind Shift+ScrollDown MoveRight
 # RPC server settings
 Set Rpc False
 Set RpcPort 7890
+
+# Scale factor
+Set ScaleFactor 1.0


### PR DESCRIPTION
This setting has until now, as far as I can tell, only been mentioned in the blog post.

One thing I would like to ask your opintion on, is whether it should also be mentioned that this setting might be required to get non-pixelated pdfs, depending on your system. For example, in Niri on 1.25x zoom, miro-pdf seems to also require 1.25x zoom to look smooth.