### PR TITLE
Use advanced text shaping for font fallback in some widgets

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use iced::{
     keyboard::Modifiers,
     theme::palette,
     widget::{
-        self, button, container, horizontal_space, pane_grid, responsive, row, scrollable,
+        self, button, container, horizontal_space, pane_grid, row, scrollable,
         scrollable::{Direction, Scrollbar},
         stack, text, vertical_space, PaneGrid,
     },
@@ -994,12 +994,14 @@ fn view_outline_items<'a>(items: &'a [OutlineItem], level: u32) -> widget::Colum
 
         let item_button = if let Some(page) = item.page {
             button(
-                container(text(&item.title).style(|theme: &Theme| {
-                    let palette = theme.extended_palette();
-                    text::Style {
-                        color: Some(palette.primary.base.color),
-                    }
-                }))
+                container(text(&item.title).shaping(text::Shaping::Advanced).style(
+                    |theme: &Theme| {
+                        let palette = theme.extended_palette();
+                        text::Style {
+                            color: Some(palette.primary.base.color),
+                        }
+                    },
+                ))
                 .padding(Padding::default().left(indent as f32)),
             )
             .style(|_: &Theme, _| widget::button::Style {
@@ -1010,12 +1012,14 @@ fn view_outline_items<'a>(items: &'a [OutlineItem], level: u32) -> widget::Colum
             .on_press(AppMessage::OutlineGoToPage(page))
         } else {
             button(
-                container(text(&item.title).style(|theme: &Theme| {
-                    let palette = theme.extended_palette();
-                    text::Style {
-                        color: Some(palette.background.weak.color),
-                    }
-                }))
+                container(text(&item.title).shaping(text::Shaping::Advanced).style(
+                    |theme: &Theme| {
+                        let palette = theme.extended_palette();
+                        text::Style {
+                            color: Some(palette.background.weak.color),
+                        }
+                    },
+                ))
                 .padding(Padding::default().left(indent as f32)),
             )
             .style(|_: &Theme, _| widget::button::Style {
@@ -1187,12 +1191,14 @@ fn file_tab<'a>(
         widget::row![
             base_button(
                 widget::row![
-                    text(file_name).font(Font {
-                        family: iced::font::Family::Name("Geist"),
-                        weight: Weight::Semibold,
-                        ..Default::default()
-                    }),
-                    text(page_progress)
+                    text(file_name)
+                        .font(Font {
+                            family: iced::font::Family::Name("Geist"),
+                            weight: Weight::Semibold,
+                            ..Default::default()
+                        })
+                        .shaping(text::Shaping::Advanced),
+                    text(page_progress).shaping(text::Shaping::Advanced)
                 ]
                 .spacing(8.0),
                 on_press

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -127,7 +127,7 @@ impl BookmarkStore {
 
     fn view_bookmark_set<'a>(&self, set: &'a BookmarkSet) -> iced::Element<'a, BookmarkMessage> {
         let mut marks = widget::column![
-            text(set.path.file_name().unwrap().to_string_lossy()),
+            text(set.path.file_name().unwrap().to_string_lossy()).shaping(text::Shaping::Advanced),
             vertical_space().height(4.0)
         ];
         for mark in &set.marks {
@@ -135,11 +135,13 @@ impl BookmarkStore {
                 button(widget::row![
                     hover(
                         text(&mark.name)
+                            .shaping(text::Shaping::Advanced)
                             .style(|_: &Theme| widget::text::Style {
                                 color: Some(iced::Color::from_rgb(0.5, 0.5, 0.5)),
                             })
                             .width(Length::Fill),
                         text(&mark.name)
+                            .shaping(text::Shaping::Advanced)
                             .style(|theme: &Theme| {
                                 let palette = theme.extended_palette();
                                 widget::text::Style {


### PR DESCRIPTION
Closes #79. I’m experiencing the same issue, even with the file tab name. See [iced-rs/iced#3047](https://github.com/iced-rs/iced/issues/3047)— it’s caused by how `iced` handles font fallback. Using the `Advanced` shaping strategy in widgets enables system font fallback when certain glyphs can’t be displayed with the default fonts.