### PR TITLE
Capture events when it's already handled

### DIFF
--- a/src/pdf/inner.rs
+++ b/src/pdf/inner.rs
@@ -376,6 +376,7 @@ where
         _viewport: &iced::Rectangle,
     ) -> iced::advanced::graphics::core::event::Status {
         let bounds = layout.bounds();
+        let mut event_handled = false;
         let out = match event {
             iced::Event::Window(event) => match event {
                 iced::window::Event::Opened {
@@ -389,6 +390,7 @@ where
                     // Handle Escape key to close links (hardcoded, not configurable)
                     iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape) => {
                         if modifiers.is_empty() && self.link_hitboxes.is_some() {
+                            event_handled = true;
                             Some(PdfMessage::CloseLinkHitboxes)
                         } else {
                             None
@@ -398,6 +400,7 @@ where
                         if let Some(keys) = &self.link_keys
                             && !keys.is_empty()
                         {
+                            event_handled = true;
                             self.pending_link_key.push_str(key_char);
                             if self.pending_link_key.len() >= keys[0].len() {
                                 match keys.iter().position(|k| **k == self.pending_link_key) {
@@ -421,7 +424,11 @@ where
         } else if self.state.bounds.size() == Vector::zero() || self.state.bounds != bounds.into() {
             shell.publish(PdfMessage::UpdateBounds(bounds.into()));
         }
-        iced::event::Status::Ignored
+        if event_handled {
+            iced::event::Status::Captured
+        } else {
+            iced::event::Status::Ignored
+        }
     }
 
     fn mouse_interaction(


### PR DESCRIPTION
When drawing link hints with `Ctrl+l` and attempting to jump to a link using the 'q' key, the application closes instead. This occurs because the event status is set to `Status::Ignored`, allowing the event to bubble up. We should return `Status::Captured` to prevent this unintended behavior.