### PR TITLE
first steps for native macos menu bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.0",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -206,7 +206,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -406,7 +406,7 @@ checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -421,6 +421,29 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "atk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
+dependencies = [
+ "atk-sys",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -576,7 +599,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -611,6 +634,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -639,7 +665,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
 dependencies = [
- "objc2 0.6.0",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -684,7 +710,7 @@ checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -704,6 +730,31 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cairo-rs"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+dependencies = [
+ "bitflags 2.11.1",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "calloop"
@@ -822,7 +873,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -887,7 +938,7 @@ checksum = "15cfadb008499abfb16146f2dfb71bfd272d324380a34d535a5a41d838be2911"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "tracing",
 ]
 
@@ -1196,7 +1247,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.0",
  "libc",
- "objc2 0.6.0",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1207,7 +1258,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1311,7 +1362,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1331,7 +1382,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1424,6 +1475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1580,7 +1641,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1694,7 +1755,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1725,6 +1786,64 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gdk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
@@ -1796,6 +1915,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gio"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1962,53 @@ name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags 2.11.1",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "glob"
@@ -1837,6 +2035,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
  "gl_generator",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1888,6 +2097,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "gtk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
+dependencies = [
+ "atk",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2193,7 +2454,7 @@ checksum = "7ef5125e110cb19cd1910a28298661c98c5d9ab02eef43594968352940e8752e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "ttf-parser",
 ]
 
@@ -2459,7 +2720,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2496,7 +2757,7 @@ dependencies = [
  "gif",
  "image-webp",
  "num-traits",
- "png",
+ "png 0.17.16",
  "qoi",
  "ravif",
  "rayon",
@@ -2566,7 +2827,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2667,7 +2928,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2692,7 +2953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2739,6 +3000,17 @@ dependencies = [
  "iced",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags 2.11.1",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2854,6 +3126,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "libxdo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
+dependencies = [
+ "libxdo-sys",
+]
+
+[[package]]
+name = "libxdo-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
+dependencies = [
+ "libc",
+ "x11",
+]
+
+[[package]]
 name = "lilt"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,7 +3221,7 @@ dependencies = [
  "quote",
  "regex-syntax 0.8.5",
  "rustc_version",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3166,6 +3457,7 @@ dependencies = [
  "iced_fonts",
  "keybinds2",
  "logos",
+ "muda",
  "mupdf",
  "num",
  "once_cell",
@@ -3188,6 +3480,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "muda"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "gtk",
+ "keyboard-types",
+ "libxdo",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.0",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.0",
+ "once_cell",
+ "png 0.18.1",
+ "thiserror 2.0.12",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "mundy"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,7 +3514,7 @@ dependencies = [
  "futures-lite",
  "jni 0.21.1",
  "ndk-context",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.0",
  "objc2-foundation 0.3.0",
  "pin-project-lite",
@@ -3414,7 +3727,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3483,10 +3796,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3516,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -3548,7 +3861,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.0",
  "libc",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-cloud-kit 0.3.0",
  "objc2-core-data 0.3.0",
  "objc2-core-foundation",
@@ -3578,7 +3891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c1948a9be5f469deadbd6bcb86ad7ff9e47b4f632380139722f7d9840c0d42c"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.0",
 ]
 
@@ -3612,7 +3925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f860f8e841f6d32f754836f51e6bc7777cd7e7053cf18528233f6811d3eceb4"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.0",
 ]
 
@@ -3623,7 +3936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.0",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3633,7 +3946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -3656,7 +3969,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ffa6bea72bf42c78b0b34e89c0bafac877d5f80bf91e159a5d96ea7f693ca56"
 dependencies = [
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.0",
 ]
 
@@ -3700,7 +4013,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.0",
  "libc",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3711,7 +4024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3759,7 +4072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb3794501bb1bee12f08dcad8c61f2a5875791ad1c6f47faa71a0f033f20071"
 dependencies = [
  "bitflags 2.11.1",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.0",
 ]
 
@@ -3915,7 +4228,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3931,6 +4244,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "pango"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -4039,7 +4377,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4074,7 +4412,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4113,6 +4451,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4172,11 +4523,54 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.22.24",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -4196,7 +4590,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "version_check",
  "yansi",
 ]
@@ -4217,7 +4611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4625,7 +5019,7 @@ dependencies = [
  "dispatch2",
  "js-sys",
  "log",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.0",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",
@@ -4930,7 +5324,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4963,7 +5357,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5260,7 +5654,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5298,6 +5692,16 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -5324,7 +5728,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5425,7 +5829,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5436,7 +5840,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5471,7 +5875,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png",
+ "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -5550,7 +5954,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5585,7 +5989,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.8",
  "toml_datetime 0.6.8",
- "toml_edit",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -5600,7 +6004,7 @@ dependencies = [
  "toml_datetime 0.7.3",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -5623,6 +6027,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.8",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.8",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
@@ -5631,7 +6057,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.8",
  "toml_datetime 0.6.8",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -5640,7 +6066,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -5715,7 +6141,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6061,7 +6487,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -6096,7 +6522,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6263,7 +6689,7 @@ dependencies = [
  "jni 0.21.1",
  "log",
  "ndk-context",
- "objc2 0.6.0",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.0",
  "url",
  "web-sys",
@@ -6557,7 +6983,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6568,7 +6994,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6579,7 +7005,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6590,7 +7016,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6958,6 +7384,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
@@ -7023,6 +7458,16 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "x11-dl"
@@ -7146,7 +7591,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -7179,7 +7624,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",
- "winnow",
+ "winnow 0.7.13",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -7192,10 +7637,10 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f325ad10eb0d0a3eb060203494c3b7ec3162a01a59db75d2deee100339709fc0"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -7209,7 +7654,7 @@ checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
- "winnow",
+ "winnow 0.7.13",
  "zvariant",
 ]
 
@@ -7245,7 +7690,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7256,7 +7701,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7276,7 +7721,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -7305,7 +7750,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7343,7 +7788,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "url",
- "winnow",
+ "winnow 0.7.13",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -7354,10 +7799,10 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74170caa85b8b84cc4935f2d56a57c7a15ea6185ccdd7eadb57e6edd90f94b2f"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "zvariant_utils",
 ]
 
@@ -7371,6 +7816,6 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn",
- "winnow",
+ "syn 2.0.100",
+ "winnow 0.7.13",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ colorgrad = "0.7.1"
 home = "0.5.11"
 iced = { version = "0.14.0", features = ["advanced", "image", "tokio", "web-colors", "lazy", "svg", "canvas"] }
 iced_aw = { version = "0.14.1", default-features = false, features = ["menu"] }
+muda = "0.19.2"
 iced_fonts = { version = "0.3.0", features = ["nerd"] }
 keybinds2 = { version = "0.2.0", features = ["iced", "serde"] }
 logos = "0.15.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use iced::{
+    Background, Border, Element, Event, Length, Padding, Shadow, Subscription, Theme,
     advanced::graphics::core::window,
     alignment,
     border::{self, Radius},
@@ -13,11 +14,10 @@ use iced::{
     keyboard::Modifiers,
     theme::palette,
     widget::{
-        self, button, container, pane_grid, row, scrollable,
+        self, PaneGrid, button, container, pane_grid, row, scrollable,
         scrollable::{Direction, Scrollbar},
-        stack, text, PaneGrid,
+        stack, text,
     },
-    Background, Border, Element, Event, Length, Padding, Shadow, Subscription, Theme,
 };
 use iced_aw::{Menu, menu::primary, menu_items};
 use iced_aw::{
@@ -44,6 +44,7 @@ use crate::{
         page_layout::PageLayout,
         widget::{OutlineItem, PdfViewer},
     },
+    macos_menu::{AppMenu, menu_bar_listener},
     recent_files::RecentFiles,
     rpc::rpc_server,
     watch::{WatchMessage, WatchNotification, file_watcher},
@@ -69,6 +70,7 @@ pub enum SidebarTab {
 
 #[derive(Debug)]
 pub struct App {
+    app_menu: AppMenu,
     pub pdfs: Vec<PdfViewer>,
     pub pdf_idx: usize,
     pub file_watcher: Option<mpsc::Sender<WatchMessage>>,
@@ -170,8 +172,10 @@ impl App {
         if CONFIG.read().unwrap().open_sidebar {
             Self::open_sidebar(&mut ps, pdf_id);
         }
+        let app_menu = AppMenu::new();
 
         Self {
+            app_menu: app_menu,
             pdfs: vec![],
             pdf_idx: 0,
             file_watcher: None,
@@ -628,7 +632,6 @@ impl App {
     fn create_menu_bar(&self) -> Element<'_, AppMessage> {
         let menu_tpl_1 = |items| Menu::new(items).max_width(300.0).offset(0.0).spacing(0.0);
         let cfg = CONFIG.read().unwrap();
-
         let exit_close_label = if self.pdfs.is_empty() {
             "Exit"
         } else {
@@ -1001,6 +1004,7 @@ impl App {
     }
 
     pub fn view(&self) -> iced::Element<'_, AppMessage> {
+        self.app_menu.init();
         let pg = PaneGrid::new(&self.pane_state, |_id, pane, _is_maximized| {
             pane_grid::Content::new(match pane.pane_type {
                 PaneType::Sidebar => self.view_sidebar(),
@@ -1323,6 +1327,7 @@ impl App {
 
         let mut subs = vec![
             keys,
+            Subscription::run(menu_bar_listener),
             Subscription::run(file_watcher).map(AppMessage::FileWatcher),
         ];
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -235,8 +235,7 @@ impl App {
     pub fn update(&mut self, message: AppMessage) -> iced::Task<AppMessage> {
         let _span = tracy_client::span!("App update");
         match message {
-            // This never gets called unless cfg.native_menu_bar is true, and the app is just
-            // starting up. This is why no `if cfg.native_menu_bar` is neccessary here.
+            // This only get's called at startup when target_os = "macos"
             AppMessage::InitializeNativeMenuBar => {
                 let m = MudaMenu::new();
                 m.init();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1339,9 +1339,11 @@ impl App {
 
         let mut subs = vec![
             keys,
-            Subscription::run(menu_bar_listener),
             Subscription::run(file_watcher).map(AppMessage::FileWatcher),
         ];
+        if self.native_menu_bar.is_some() {
+            subs.push(Subscription::run(menu_bar_listener));
+        }
 
         let config = CONFIG.read().unwrap();
         if config.rpc_enabled {

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,7 +44,7 @@ use crate::{
         page_layout::PageLayout,
         widget::{OutlineItem, PdfViewer},
     },
-    macos_menu::{MudaMenu, menu_bar_listener},
+    platform_specific,
     recent_files::RecentFiles,
     rpc::rpc_server,
     watch::{WatchMessage, WatchNotification, file_watcher},
@@ -70,7 +70,7 @@ pub enum SidebarTab {
 
 #[derive(Debug)]
 pub struct App {
-    native_menu_bar: Option<MudaMenu>,
+    mac_menu: Option<platform_specific::macos::Menu>,
     pub pdfs: Vec<PdfViewer>,
     pub pdf_idx: usize,
     pub file_watcher: Option<mpsc::Sender<WatchMessage>>,
@@ -92,7 +92,7 @@ pub struct App {
 
 #[derive(Debug, Clone, Serialize, Deserialize, EnumString, Default)]
 pub enum AppMessage {
-    InitializeNativeMenuBar,
+    InitializeMacMenu,
     OpenFile(PathBuf),
     #[strum(disabled)]
     #[serde(skip)]
@@ -179,7 +179,7 @@ impl App {
         }
 
         Self {
-            native_menu_bar: None,
+            mac_menu: None,
             pdfs: vec![],
             pdf_idx: 0,
             file_watcher: None,
@@ -258,11 +258,10 @@ impl App {
     pub fn update(&mut self, message: AppMessage) -> iced::Task<AppMessage> {
         let _span = tracy_client::span!("App update");
         match message {
-            // This only get's called at startup when target_os = "macos"
-            AppMessage::InitializeNativeMenuBar => {
-                let m = MudaMenu::new();
+            AppMessage::InitializeMacMenu => {
+                let m = platform_specific::macos::Menu::new();
                 m.init();
-                self.native_menu_bar = Some(m);
+                self.mac_menu = Some(m);
                 iced::Task::none()
             }
             AppMessage::OpenFile(path_buf) => {
@@ -1055,7 +1054,7 @@ impl App {
                                     .into(),
                             );
                         }
-                        if self.native_menu_bar.is_none() {
+                        if self.mac_menu.is_none() {
                             let menu_bar = self.create_menu_bar();
                             widget::column![menu_bar, stack(stack_children)].into()
                         } else {
@@ -1351,9 +1350,7 @@ impl App {
             keys,
             Subscription::run(file_watcher).map(AppMessage::FileWatcher),
         ];
-        if self.native_menu_bar.is_some() {
-            subs.push(Subscription::run(menu_bar_listener));
-        }
+        subs.append(&mut platform_specific::listeners());
 
         let config = CONFIG.read().unwrap();
         if config.rpc_enabled {

--- a/src/app.rs
+++ b/src/app.rs
@@ -92,6 +92,7 @@ pub struct App {
 
 #[derive(Debug, Clone, Serialize, Deserialize, EnumString, Default)]
 pub enum AppMessage {
+    InitializeNativeMenuBar,
     OpenFile(PathBuf),
     CloseFile(PathBuf),
     OpenNewFileFinder,
@@ -172,10 +173,8 @@ impl App {
         if CONFIG.read().unwrap().open_sidebar {
             Self::open_sidebar(&mut ps, pdf_id);
         }
-        let app_menu = AppMenu::new();
-
         Self {
-            app_menu: app_menu,
+            app_menu: AppMenu::new(),
             pdfs: vec![],
             pdf_idx: 0,
             file_watcher: None,
@@ -234,6 +233,10 @@ impl App {
     pub fn update(&mut self, message: AppMessage) -> iced::Task<AppMessage> {
         let _span = tracy_client::span!("App update");
         match message {
+            AppMessage::InitializeNativeMenuBar => {
+                self.app_menu.init();
+                iced::Task::none()
+            },
             AppMessage::OpenFile(path_buf) => {
                 let path_buf = canonicalize(path_buf).unwrap();
                 self.recent_files.add_recent(path_buf.clone());
@@ -1004,7 +1007,6 @@ impl App {
     }
 
     pub fn view(&self) -> iced::Element<'_, AppMessage> {
-        self.app_menu.init();
         let pg = PaneGrid::new(&self.pane_state, |_id, pane, _is_maximized| {
             pane_grid::Content::new(match pane.pane_type {
                 PaneType::Sidebar => self.view_sidebar(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -259,7 +259,8 @@ impl App {
         let _span = tracy_client::span!("App update");
         match message {
             AppMessage::InitializeMacMenu => {
-                let m = platform_specific::macos::Menu::new();
+                let recent_files = self.recent_files.get_recent();
+                let m = platform_specific::macos::Menu::new(recent_files);
                 m.init();
                 self.mac_menu = Some(m);
                 iced::Task::none()
@@ -267,6 +268,10 @@ impl App {
             AppMessage::OpenFile(path_buf) => {
                 let path_buf = canonicalize(path_buf).unwrap();
                 self.recent_files.add_recent(path_buf.clone());
+                if let Some(m) = &self.mac_menu {
+                    let recent_files = self.recent_files.get_recent();
+                    m.shared_menu.update_recent_files_submenu(recent_files);
+                }
                 self.open_pdf(path_buf)
             }
             AppMessage::OpenTempFile(path_buf) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,7 +44,7 @@ use crate::{
         page_layout::PageLayout,
         widget::{OutlineItem, PdfViewer},
     },
-    macos_menu::{AppMenu, menu_bar_listener},
+    macos_menu::{MudaMenu, menu_bar_listener},
     recent_files::RecentFiles,
     rpc::rpc_server,
     watch::{WatchMessage, WatchNotification, file_watcher},
@@ -70,7 +70,7 @@ pub enum SidebarTab {
 
 #[derive(Debug)]
 pub struct App {
-    app_menu: AppMenu,
+    native_menu_bar: Option<MudaMenu>,
     pub pdfs: Vec<PdfViewer>,
     pub pdf_idx: usize,
     pub file_watcher: Option<mpsc::Sender<WatchMessage>>,
@@ -167,14 +167,16 @@ impl App {
     }
 
     pub fn new(bookmark_store: BookmarkStore, recent_files: RecentFiles) -> Self {
+        let cfg = CONFIG.read().unwrap();
         let (mut ps, pdf_id) = pane_grid::State::new(Pane {
             pane_type: PaneType::Pdf,
         });
-        if CONFIG.read().unwrap().open_sidebar {
+        if cfg.open_sidebar {
             Self::open_sidebar(&mut ps, pdf_id);
         }
+
         Self {
-            app_menu: AppMenu::new(),
+            native_menu_bar: None,
             pdfs: vec![],
             pdf_idx: 0,
             file_watcher: None,
@@ -233,10 +235,14 @@ impl App {
     pub fn update(&mut self, message: AppMessage) -> iced::Task<AppMessage> {
         let _span = tracy_client::span!("App update");
         match message {
+            // This never gets called unless cfg.native_menu_bar is true, and the app is just
+            // starting up. This is why no `if cfg.native_menu_bar` is neccessary here.
             AppMessage::InitializeNativeMenuBar => {
-                self.app_menu.init();
+                let m = MudaMenu::new();
+                m.init();
+                self.native_menu_bar = Some(m);
                 iced::Task::none()
-            },
+            }
             AppMessage::OpenFile(path_buf) => {
                 let path_buf = canonicalize(path_buf).unwrap();
                 self.recent_files.add_recent(path_buf.clone());
@@ -1011,7 +1017,6 @@ impl App {
             pane_grid::Content::new(match pane.pane_type {
                 PaneType::Sidebar => self.view_sidebar(),
                 PaneType::Pdf => {
-                    let menu_bar = self.create_menu_bar();
                     let pdf_content: iced::Element<'_, AppMessage> = if self.pdfs.is_empty() {
                         widget::space::vertical().into()
                     } else {
@@ -1040,7 +1045,12 @@ impl App {
                                     .into(),
                             );
                         }
-                        widget::column![menu_bar, stack(stack_children)].into()
+                        if self.native_menu_bar.is_none() {
+                            let menu_bar = self.create_menu_bar();
+                            widget::column![menu_bar, stack(stack_children)].into()
+                        } else {
+                            widget::column![stack(stack_children)].into()
+                        }
                     }
                 }
             })

--- a/src/common_menu.rs
+++ b/src/common_menu.rs
@@ -1,0 +1,24 @@
+use crate::{config::BindableMessage};
+
+pub enum CommonMenuItem {
+    Button(String, BindableMessage),
+    RecentFiles,
+    Separator,
+}
+pub struct CommonMenu {
+    pub skeleton: Vec<(String, Vec<CommonMenuItem>)>,
+}
+
+impl CommonMenu {
+    pub fn new() -> Self {
+        let skeleton = vec![(
+            String::from("File"),
+            vec![
+                CommonMenuItem::Button(String::from("Open File"), BindableMessage::OpenFileFinder),
+                CommonMenuItem::Button(String::from("Print PDF"), BindableMessage::PrintPdf),
+                CommonMenuItem::RecentFiles,
+            ],
+        )];
+        Self { skeleton: skeleton }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,6 +199,13 @@ pub enum BindableMessage {
     PresentationLayout,
 }
 
+// This is used to convert a BindableMessage to itself but as a string
+impl fmt::Display for BindableMessage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 impl From<BindableMessage> for AppMessage {
     fn from(val: BindableMessage) -> Self {
         match val {
@@ -278,6 +285,7 @@ pub struct Config {
     pub dark_mode: bool,
     pub invert_pdf: bool,
     pub open_sidebar: bool,
+    pub native_menu_bar: bool,
     pub default_search_method: SearchMethod,
     pub open_fullscreen_default: bool,
     pub open_presentation_default: bool,
@@ -288,11 +296,11 @@ impl Config {
         Config {
             keyboard: Keybinds::new(vec![]),
             mouse: Vec::new(),
+            native_menu_bar: true,
             trackpad_sensitivity: 1.0,
             ..Default::default()
         }
     }
-
     pub fn get_binding_for_msg(&self, msg: BindableMessage) -> Option<Keybind<BindableMessage>> {
         let binds = self.keyboard.as_slice();
         binds.iter().find(|b| b.action == msg).cloned()
@@ -808,6 +816,10 @@ impl Default for Config {
             default_search_method: SearchMethod::PlainText,
             open_fullscreen_default: false,
             open_presentation_default: false,
+            #[cfg(target_os = "macos")]
+            native_menu_bar: true,
+            #[cfg(not(target_os = "macos"))]
+            native_menu_bar: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,7 +285,6 @@ pub struct Config {
     pub dark_mode: bool,
     pub invert_pdf: bool,
     pub open_sidebar: bool,
-    pub native_menu_bar: bool,
     pub default_search_method: SearchMethod,
     pub open_fullscreen_default: bool,
     pub open_presentation_default: bool,
@@ -296,7 +295,6 @@ impl Config {
         Config {
             keyboard: Keybinds::new(vec![]),
             mouse: Vec::new(),
-            native_menu_bar: true,
             trackpad_sensitivity: 1.0,
             ..Default::default()
         }
@@ -816,10 +814,6 @@ impl Default for Config {
             default_search_method: SearchMethod::PlainText,
             open_fullscreen_default: false,
             open_presentation_default: false,
-            #[cfg(target_os = "macos")]
-            native_menu_bar: true,
-            #[cfg(not(target_os = "macos"))]
-            native_menu_bar: false,
         }
     }
 }

--- a/src/macos_menu.rs
+++ b/src/macos_menu.rs
@@ -1,10 +1,9 @@
 use muda::{AcceleratorParseError, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
-use muda::accelerator::{Accelerator};
+use muda::accelerator::{KeyAccelerator};
 use crate::CONFIG;
 use keybinds2::{Keybind};
 use crate::config::BindableMessage;
 use crate::app::AppMessage;
-use crate::pdf::PdfMessage;
 use std::fmt;
 use std::str::FromStr;
 
@@ -38,52 +37,32 @@ impl AppMenu {
         // The first item appended always has to be the app (sub)menu (mac will override whatever else is present)
         menu.append(&app_submenu).unwrap();
 
-        let cfg = CONFIG.read().unwrap();
         let file_submenu = Submenu::with_items(
             "&File",
             true,
             &[
-                &MenuItem::with_id(
-                    "OpenFileFinder",
-                    "Open File",
-                    true,
-                    Some(
-                        keybind_to_accelerator(
-                            cfg.get_binding_for_msg(BindableMessage::OpenFileFinder)
-                                .unwrap(),
-                        )
-                        .unwrap(),
-                    ),
-                ),
-                &MenuItem::with_id(
-                    "PrintPdf",
-                    "Print",
-                    true,
-                    Some(
-                        keybind_to_accelerator(
-                            cfg.get_binding_for_msg(BindableMessage::PrintPdf).unwrap(),
-                        )
-                        .unwrap(),
-                    ),
-                ),
+                &new_menu_item("Open File", BindableMessage::OpenFileFinder),
+                &new_menu_item("Print PDF", BindableMessage::PrintPdf),
             ],
         )
         .unwrap();
         let view_submenu = Submenu::with_items(
             "&View",
             true,
-            &[&MenuItem::with_id(
-                "ToggleUIDarkMode",
-                "Toggle UI Dark Mode",
-                true,
-                Some(
-                    keybind_to_accelerator(
-                        cfg.get_binding_for_msg(BindableMessage::ToggleDarkModeUi)
-                            .unwrap(),
-                    )
-                    .unwrap(),
+            &[
+                &new_menu_item("Toggle UI Dark Mode", BindableMessage::ToggleDarkModeUi),
+                &new_menu_item("Toggle PDF Dark Mode", BindableMessage::ToggleDarkModePdf),
+                &new_menu_item("Toggle Page Borders", BindableMessage::TogglePageBorders),
+                &new_menu_item("Zoom In", BindableMessage::ZoomIn),
+                &new_menu_item("Zoom Out", BindableMessage::ZoomOut),
+                &new_menu_item("Zoom to 100%", BindableMessage::ZoomHome),
+                &new_menu_item("Fit To Screen", BindableMessage::ZoomFit),
+                &new_menu_item("Toggle Sidebar", BindableMessage::ToggleSidebar),
+                &new_menu_item(
+                    "Toggle Presentation Mode",
+                    BindableMessage::TogglePresentationMode,
                 ),
-            )],
+            ],
         )
         .unwrap();
         let window_submenu = Submenu::with_items(
@@ -108,7 +87,6 @@ impl AppMenu {
         }
     }
 
-    // This can not be called inside new(), must be done in the view.
     pub fn init(&self) {
         // #[cfg(target_os = "macos")]
         // {
@@ -117,6 +95,41 @@ impl AppMenu {
         self.help_submenu.set_as_help_menu_for_nsapp();
         // }
     }
+}
+
+// This is used to convert a BindableMessage to itself but as a string
+impl fmt::Display for BindableMessage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+// Our MenuItems will have id equal to the BindableMessage enum values as a string.
+// For example, the Open file menu item will have id of "OpenFileFinder" (corresponding to BindableMessage::OpenFileFinder)
+pub fn new_menu_item(label: &str, msg: BindableMessage) -> MenuItem {
+    let cfg = CONFIG.read().unwrap();
+    println!("{:?}", msg.to_string());
+    let menu_item = MenuItem::with_id(
+        msg.to_string(),
+        label,
+        true,
+        None,
+        
+    );
+    let keyaccel = keybind_to_keyaccelerator(cfg.get_binding_for_msg(msg).unwrap()).unwrap();
+    menu_item.set_key_accelerator(Some(keyaccel)).unwrap();
+
+    return menu_item;
+}
+
+// Converts a keybinds2::Keybind into a muda::KeyAccelerator.
+// Ideally we'd want a single system for managing keybinds, but as muda uses KeyAccelerator
+// realistically I don't see how this is possible. This is fine for now.
+pub fn keybind_to_keyaccelerator(
+    keybind: Keybind<BindableMessage>,
+) -> Result<KeyAccelerator, AcceleratorParseError> {
+    let keybind_as_string = keybind.seq.as_slice()[0].to_string();
+    return KeyAccelerator::from_str(&keybind_as_string);
 }
 
 // Dummy debug for now (muda doesn't implement debug for some reason?)
@@ -130,31 +143,11 @@ pub fn menu_bar_listener() -> impl iced::futures::Stream<Item = AppMessage> {
     iced::stream::channel(100, async |mut sender| {
         loop {
             if let Ok(event) = MenuEvent::receiver().try_recv() {
-                match (&event.id().0).as_str() {
-                    "OpenFileFinder" => {
-                        let _ = sender.try_send(AppMessage::OpenNewFileFinder);
-                    }
-                    "PrintPdf" => {
-                        let _ = sender.try_send(AppMessage::PdfMessage(PdfMessage::PrintPdf));
-                    }
-                    "ToggleUIDarkMode" => {
-                        let _ = sender.try_send(AppMessage::ToggleDarkModeUi);
-                    }
-                    _ => {}
-                }
+                let msg = BindableMessage::from_str((&event.id().0).as_str()).unwrap();
+                let _ = sender.try_send(AppMessage::from(msg));
             } else {
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
         }
     })
-}
-
-// Converts a keybinds2::Keybind into a muda::Accelerator.
-// Ideally we'd want a single system for managing keybinds, but as muda uses Accelerator
-// realistically I don't see how this is possible. This is fine for now.
-pub fn keybind_to_accelerator(
-    keybind: Keybind<BindableMessage>,
-) -> Result<Accelerator, AcceleratorParseError> {
-    let keybind_as_string = keybind.seq.as_slice()[0].to_string();
-    return Accelerator::from_str(&keybind_as_string);
 }

--- a/src/macos_menu.rs
+++ b/src/macos_menu.rs
@@ -7,7 +7,7 @@ use crate::app::AppMessage;
 use std::fmt;
 use std::str::FromStr;
 
-pub struct AppMenu {
+pub struct MudaMenu {
     menu: Menu,
     // These are special in the macos menu bar
     window_submenu: Submenu,
@@ -15,8 +15,7 @@ pub struct AppMenu {
 }
 // TODO:
 // - Support different languages
-// - test on non-mac OSes
-impl AppMenu {
+impl MudaMenu {
     pub fn new() -> Self {
         let menu = Menu::new();
 
@@ -34,8 +33,7 @@ impl AppMenu {
                 &PredefinedMenuItem::quit(None),
             ])
             .unwrap();
-        // The first item appended always has to be the app (sub)menu (mac will override whatever else is present)
-        menu.append(&app_submenu).unwrap();
+        
 
         let file_submenu = Submenu::with_items(
             "&File",
@@ -93,7 +91,9 @@ impl AppMenu {
         )
         .unwrap();
         let help_submenu = Submenu::new("&Help", true);
-        menu.append_items(&[&file_submenu, &view_submenu, &layout_submenu, &window_submenu, &help_submenu])
+        
+        // The first item appended always has to be the app (sub)menu (mac will override whatever else is present)
+        menu.append_items(&[&app_submenu, &file_submenu, &view_submenu, &layout_submenu, &window_submenu, &help_submenu])
             .unwrap();
         Self {
             menu,
@@ -103,19 +103,9 @@ impl AppMenu {
     }
 
     pub fn init(&self) {
-        // #[cfg(target_os = "macos")]
-        // {
         self.menu.init_for_nsapp();
         self.window_submenu.set_as_windows_menu_for_nsapp();
         self.help_submenu.set_as_help_menu_for_nsapp();
-        // }
-    }
-}
-
-// This is used to convert a BindableMessage to itself but as a string
-impl fmt::Display for BindableMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
     }
 }
 
@@ -141,7 +131,7 @@ pub fn keybind_to_keyaccelerator(
 }
 
 // Dummy debug for now (muda doesn't implement debug for some reason?)
-impl fmt::Debug for AppMenu {
+impl fmt::Debug for MudaMenu {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AppMenu").finish()
     }

--- a/src/macos_menu.rs
+++ b/src/macos_menu.rs
@@ -33,7 +33,6 @@ impl MudaMenu {
                 &PredefinedMenuItem::quit(None),
             ])
             .unwrap();
-        
 
         let file_submenu = Submenu::with_items(
             "&File",
@@ -91,10 +90,17 @@ impl MudaMenu {
         )
         .unwrap();
         let help_submenu = Submenu::new("&Help", true);
-        
+
         // The first item appended always has to be the app (sub)menu (mac will override whatever else is present)
-        menu.append_items(&[&app_submenu, &file_submenu, &view_submenu, &layout_submenu, &window_submenu, &help_submenu])
-            .unwrap();
+        menu.append_items(&[
+            &app_submenu,
+            &file_submenu,
+            &view_submenu,
+            &layout_submenu,
+            &window_submenu,
+            &help_submenu,
+        ])
+        .unwrap();
         Self {
             menu,
             window_submenu,
@@ -103,9 +109,12 @@ impl MudaMenu {
     }
 
     pub fn init(&self) {
-        self.menu.init_for_nsapp();
-        self.window_submenu.set_as_windows_menu_for_nsapp();
-        self.help_submenu.set_as_help_menu_for_nsapp();
+        #[cfg(target_os = "macos")]
+        {
+            self.menu.init_for_nsapp();
+            self.window_submenu.set_as_windows_menu_for_nsapp();
+            self.help_submenu.set_as_help_menu_for_nsapp();
+        }
     }
 }
 

--- a/src/macos_menu.rs
+++ b/src/macos_menu.rs
@@ -1,0 +1,160 @@
+use muda::{AcceleratorParseError, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
+use muda::accelerator::{Accelerator};
+use crate::CONFIG;
+use keybinds2::{Keybind};
+use crate::config::BindableMessage;
+use crate::app::AppMessage;
+use crate::pdf::PdfMessage;
+use std::fmt;
+use std::str::FromStr;
+
+pub struct AppMenu {
+    menu: Menu,
+    // These are special in the macos menu bar
+    window_submenu: Submenu,
+    help_submenu: Submenu,
+}
+// TODO:
+// - Support different languages
+// - test on non-mac OSes
+impl AppMenu {
+    pub fn new() -> Self {
+        let menu = Menu::new();
+
+        let app_submenu = Submenu::new("App", true);
+        app_submenu
+            .append_items(&[
+                &PredefinedMenuItem::about(None, None),
+                &PredefinedMenuItem::separator(),
+                &PredefinedMenuItem::services(None),
+                &PredefinedMenuItem::separator(),
+                &PredefinedMenuItem::hide(None),
+                &PredefinedMenuItem::hide_others(None),
+                &PredefinedMenuItem::show_all(None),
+                &PredefinedMenuItem::separator(),
+                &PredefinedMenuItem::quit(None),
+            ])
+            .unwrap();
+        // The first item appended always has to be the app (sub)menu (mac will override whatever else is present)
+        menu.append(&app_submenu).unwrap();
+
+        let cfg = CONFIG.read().unwrap();
+        let file_submenu = Submenu::with_items(
+            "&File",
+            true,
+            &[
+                &MenuItem::with_id(
+                    "OpenFileFinder",
+                    "Open File",
+                    true,
+                    Some(
+                        keybind_to_accelerator(
+                            cfg.get_binding_for_msg(BindableMessage::OpenFileFinder)
+                                .unwrap(),
+                        )
+                        .unwrap(),
+                    ),
+                ),
+                &MenuItem::with_id(
+                    "PrintPdf",
+                    "Print",
+                    true,
+                    Some(
+                        keybind_to_accelerator(
+                            cfg.get_binding_for_msg(BindableMessage::PrintPdf).unwrap(),
+                        )
+                        .unwrap(),
+                    ),
+                ),
+            ],
+        )
+        .unwrap();
+        let view_submenu = Submenu::with_items(
+            "&View",
+            true,
+            &[&MenuItem::with_id(
+                "ToggleUIDarkMode",
+                "Toggle UI Dark Mode",
+                true,
+                Some(
+                    keybind_to_accelerator(
+                        cfg.get_binding_for_msg(BindableMessage::ToggleDarkModeUi)
+                            .unwrap(),
+                    )
+                    .unwrap(),
+                ),
+            )],
+        )
+        .unwrap();
+        let window_submenu = Submenu::with_items(
+            "&Window",
+            true,
+            &[
+                &PredefinedMenuItem::minimize(None),
+                &PredefinedMenuItem::maximize(None),
+                &PredefinedMenuItem::close_window(None),
+                &PredefinedMenuItem::fullscreen(None),
+                &PredefinedMenuItem::bring_all_to_front(None),
+            ],
+        )
+        .unwrap();
+        let help_submenu = Submenu::new("&Help", true);
+        menu.append_items(&[&file_submenu, &view_submenu, &window_submenu, &help_submenu])
+            .unwrap();
+        Self {
+            menu,
+            window_submenu,
+            help_submenu,
+        }
+    }
+
+    // This can not be called inside new(), must be done in the view.
+    pub fn init(&self) {
+        // #[cfg(target_os = "macos")]
+        // {
+        self.menu.init_for_nsapp();
+        self.window_submenu.set_as_windows_menu_for_nsapp();
+        self.help_submenu.set_as_help_menu_for_nsapp();
+        // }
+    }
+}
+
+// Dummy debug for now (muda doesn't implement debug for some reason?)
+impl fmt::Debug for AppMenu {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AppMenu").finish()
+    }
+}
+
+pub fn menu_bar_listener() -> impl iced::futures::Stream<Item = AppMessage> {
+    iced::stream::channel(100, async |mut sender| {
+        loop {
+            if let Ok(event) = MenuEvent::receiver().try_recv() {
+                match (&event.id().0).as_str() {
+                    "OpenFileFinder" => {
+                        let _ = sender.try_send(AppMessage::OpenNewFileFinder);
+                    }
+                    "PrintPdf" => {
+                        let _ = sender.try_send(AppMessage::PdfMessage(PdfMessage::PrintPdf));
+                    }
+                    "ToggleUIDarkMode" => {
+                        let _ = sender.try_send(AppMessage::ToggleDarkModeUi);
+                    }
+                    _ => {}
+                }
+            } else {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        }
+    })
+}
+
+// Converts a keybinds2::Keybind into a muda::Accelerator.
+// Ideally we'd want a single system for managing keybinds, but as muda uses Accelerator
+// realistically I don't see how this is possible. This is fine for now.
+pub fn keybind_to_accelerator(
+    keybind: Keybind<BindableMessage>,
+) -> Result<Accelerator, AcceleratorParseError> {
+    let keybind_as_string = keybind.seq.as_slice()[0].to_string();
+    return Accelerator::from_str(&keybind_as_string);
+}

--- a/src/macos_menu.rs
+++ b/src/macos_menu.rs
@@ -65,6 +65,21 @@ impl AppMenu {
             ],
         )
         .unwrap();
+        let layout_submenu = Submenu::with_items(
+            "&Layout",
+            true,
+            &[
+                &new_menu_item("Toggle Sidebar", BindableMessage::ToggleSidebar),
+                &new_menu_item("Single Page", BindableMessage::SinglePageLayout),
+                &new_menu_item("Double Page", BindableMessage::DoublePageLayout),
+                &new_menu_item(
+                    "Double Page With Title Page",
+                    BindableMessage::DoublePageTitlePageLayout,
+                ),
+                &new_menu_item("Presentation", BindableMessage::PresentationLayout),
+            ],
+        )
+        .unwrap();
         let window_submenu = Submenu::with_items(
             "&Window",
             true,
@@ -78,7 +93,7 @@ impl AppMenu {
         )
         .unwrap();
         let help_submenu = Submenu::new("&Help", true);
-        menu.append_items(&[&file_submenu, &view_submenu, &window_submenu, &help_submenu])
+        menu.append_items(&[&file_submenu, &view_submenu, &layout_submenu, &window_submenu, &help_submenu])
             .unwrap();
         Self {
             menu,
@@ -108,14 +123,7 @@ impl fmt::Display for BindableMessage {
 // For example, the Open file menu item will have id of "OpenFileFinder" (corresponding to BindableMessage::OpenFileFinder)
 pub fn new_menu_item(label: &str, msg: BindableMessage) -> MenuItem {
     let cfg = CONFIG.read().unwrap();
-    println!("{:?}", msg.to_string());
-    let menu_item = MenuItem::with_id(
-        msg.to_string(),
-        label,
-        true,
-        None,
-        
-    );
+    let menu_item = MenuItem::with_id(msg.to_string(), label, true, None);
     let keyaccel = keybind_to_keyaccelerator(cfg.get_binding_for_msg(msg).unwrap()).unwrap();
     menu_item.set_key_accelerator(Some(keyaccel)).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ mod config;
 mod geometry;
 mod icons;
 mod jumplist;
-mod macos_menu;
 mod pdf;
+mod platform_specific;
 mod recent_files;
 mod rpc;
 mod watch;
@@ -171,10 +171,8 @@ fn main() -> anyhow::Result<()> {
             let mut startup_tasks =
                 startup_tasks.chain(iced::window::latest().map(app::AppMessage::FoundWindowId));
 
-            #[cfg(target_os = "macos")]
-            {
-                startup_tasks =
-                    startup_tasks.chain(iced::Task::done(app::AppMessage::InitializeNativeMenuBar));
+            for task in platform_specific::startup_tasks().into_iter() {
+                startup_tasks = startup_tasks.chain(task);
             }
 
             // NOTE: The default state is in windowed, non presentation mode. Using the toggles is

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,12 +151,10 @@ fn main() -> anyhow::Result<()> {
     }
     let cfg_fullscreen;
     let cfg_presentation;
-    let cfg_native_menu_bar;
     {
         let config = CONFIG.read().unwrap();
         cfg_presentation = config.open_presentation_default;
         cfg_fullscreen = config.open_fullscreen_default;
-        cfg_native_menu_bar = config.native_menu_bar;
     }
     Ok(iced::application(
         move || {
@@ -172,7 +170,8 @@ fn main() -> anyhow::Result<()> {
             let mut startup_tasks =
                 startup_tasks.chain(iced::window::latest().map(app::AppMessage::FoundWindowId));
 
-            if cfg_native_menu_bar {
+            #[cfg(target_os = "macos")]
+            {
                 startup_tasks =
                     startup_tasks.chain(iced::Task::done(app::AppMessage::InitializeNativeMenuBar));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod icons;
 mod jumplist;
 mod pdf;
 mod platform_specific;
+mod common_menu;
 mod recent_files;
 mod rpc;
 mod watch;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod pdf;
 mod recent_files;
 mod rpc;
 mod watch;
+mod macos_menu;
 
 // of the screen
 // TODO: Figure out why hovering over a menu disables all other inputs/buttons in the program (write
@@ -155,7 +156,6 @@ fn main() -> anyhow::Result<()> {
         cfg_presentation = config.open_presentation_default;
         cfg_fullscreen = config.open_fullscreen_default;
     }
-
     Ok(iced::application(
         move || {
             let path = args.path.clone();
@@ -197,6 +197,7 @@ fn main() -> anyhow::Result<()> {
 pub fn theme(app: &App) -> Theme {
     use iced::theme::palette::{*};
 
+    // TODO: Custom themes for UI, and maybe custom pdf background color (perhaps in json files?).
     let miro_light = Theme::custom_with_fn(
         "Miro Light".to_string(),
         iced::theme::Palette {

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,10 +151,12 @@ fn main() -> anyhow::Result<()> {
     }
     let cfg_fullscreen;
     let cfg_presentation;
+    let cfg_native_menu_bar;
     {
         let config = CONFIG.read().unwrap();
         cfg_presentation = config.open_presentation_default;
         cfg_fullscreen = config.open_fullscreen_default;
+        cfg_native_menu_bar = config.native_menu_bar;
     }
     Ok(iced::application(
         move || {
@@ -167,9 +169,13 @@ fn main() -> anyhow::Result<()> {
                 Some(p) => iced::Task::done(app::AppMessage::OpenFile(p)),
                 None => iced::Task::none(),
             };
-            let mut startup_tasks = startup_tasks.chain(iced::Task::done(app::AppMessage::InitializeNativeMenuBar));
-            startup_tasks =
+            let mut startup_tasks =
                 startup_tasks.chain(iced::window::latest().map(app::AppMessage::FoundWindowId));
+
+            if cfg_native_menu_bar {
+                startup_tasks =
+                    startup_tasks.chain(iced::Task::done(app::AppMessage::InitializeNativeMenuBar));
+            }
 
             // NOTE: The default state is in windowed, non presentation mode. Using the toggles is
             // thus deterministic.
@@ -177,7 +183,8 @@ fn main() -> anyhow::Result<()> {
                 startup_tasks = startup_tasks.chain(iced::Task::done(AppMessage::ToggleFullscreen));
             }
             if args.presentation || cfg_presentation {
-                startup_tasks = startup_tasks.chain(iced::Task::done(AppMessage::TogglePresentationMode));
+                startup_tasks =
+                    startup_tasks.chain(iced::Task::done(AppMessage::TogglePresentationMode));
             }
 
             (state, startup_tasks)

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,11 @@ mod config;
 mod geometry;
 mod icons;
 mod jumplist;
+mod macos_menu;
 mod pdf;
 mod recent_files;
 mod rpc;
 mod watch;
-mod macos_menu;
 
 // of the screen
 // TODO: Figure out why hovering over a menu disables all other inputs/buttons in the program (write
@@ -163,23 +163,24 @@ fn main() -> anyhow::Result<()> {
                 BookmarkStore::system_store().unwrap_or_default(),
                 RecentFiles::system_store().unwrap_or_default(),
             );
-            let file_task = match path {
+            let startup_tasks = match path {
                 Some(p) => iced::Task::done(app::AppMessage::OpenFile(p)),
                 None => iced::Task::none(),
             };
-            let mut file_task =
-                file_task.chain(iced::window::latest().map(app::AppMessage::FoundWindowId));
+            let mut startup_tasks = startup_tasks.chain(iced::Task::done(app::AppMessage::InitializeNativeMenuBar));
+            startup_tasks =
+                startup_tasks.chain(iced::window::latest().map(app::AppMessage::FoundWindowId));
 
             // NOTE: The default state is in windowed, non presentation mode. Using the toggles is
             // thus deterministic.
             if args.fullscreen || cfg_fullscreen {
-                file_task = file_task.chain(iced::Task::done(AppMessage::ToggleFullscreen));
+                startup_tasks = startup_tasks.chain(iced::Task::done(AppMessage::ToggleFullscreen));
             }
             if args.presentation || cfg_presentation {
-                file_task = file_task.chain(iced::Task::done(AppMessage::TogglePresentationMode));
+                startup_tasks = startup_tasks.chain(iced::Task::done(AppMessage::TogglePresentationMode));
             }
 
-            (state, file_task)
+            (state, startup_tasks)
         },
         App::update,
         App::view,

--- a/src/platform_specific/macos.rs
+++ b/src/platform_specific/macos.rs
@@ -1,5 +1,5 @@
-use muda::{AcceleratorParseError, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
 use muda::accelerator::{KeyAccelerator};
+use muda::AcceleratorParseError;
 use crate::CONFIG;
 use keybinds2::{Keybind};
 use crate::config::BindableMessage;
@@ -7,34 +7,34 @@ use crate::app::AppMessage;
 use std::fmt;
 use std::str::FromStr;
 
-pub struct MudaMenu {
-    menu: Menu,
+pub struct Menu {
+    menu: muda::Menu,
     // These are special in the macos menu bar
-    window_submenu: Submenu,
-    help_submenu: Submenu,
+    window_submenu: muda::Submenu,
+    help_submenu: muda::Submenu,
 }
 // TODO:
 // - Support different languages
-impl MudaMenu {
+impl Menu {
     pub fn new() -> Self {
-        let menu = Menu::new();
+        let menu = muda::Menu::new();
 
-        let app_submenu = Submenu::new("App", true);
+        let app_submenu = muda::Submenu::new("App", true);
         app_submenu
             .append_items(&[
-                &PredefinedMenuItem::about(None, None),
-                &PredefinedMenuItem::separator(),
-                &PredefinedMenuItem::services(None),
-                &PredefinedMenuItem::separator(),
-                &PredefinedMenuItem::hide(None),
-                &PredefinedMenuItem::hide_others(None),
-                &PredefinedMenuItem::show_all(None),
-                &PredefinedMenuItem::separator(),
-                &PredefinedMenuItem::quit(None),
+                &muda::PredefinedMenuItem::about(None, None),
+                &muda::PredefinedMenuItem::separator(),
+                &muda::PredefinedMenuItem::services(None),
+                &muda::PredefinedMenuItem::separator(),
+                &muda::PredefinedMenuItem::hide(None),
+                &muda::PredefinedMenuItem::hide_others(None),
+                &muda::PredefinedMenuItem::show_all(None),
+                &muda::PredefinedMenuItem::separator(),
+                &muda::PredefinedMenuItem::quit(None),
             ])
             .unwrap();
 
-        let file_submenu = Submenu::with_items(
+        let file_submenu = muda::Submenu::with_items(
             "&File",
             true,
             &[
@@ -43,7 +43,7 @@ impl MudaMenu {
             ],
         )
         .unwrap();
-        let view_submenu = Submenu::with_items(
+        let view_submenu = muda::Submenu::with_items(
             "&View",
             true,
             &[
@@ -62,7 +62,7 @@ impl MudaMenu {
             ],
         )
         .unwrap();
-        let layout_submenu = Submenu::with_items(
+        let layout_submenu = muda::Submenu::with_items(
             "&Layout",
             true,
             &[
@@ -77,19 +77,19 @@ impl MudaMenu {
             ],
         )
         .unwrap();
-        let window_submenu = Submenu::with_items(
+        let window_submenu = muda::Submenu::with_items(
             "&Window",
             true,
             &[
-                &PredefinedMenuItem::minimize(None),
-                &PredefinedMenuItem::maximize(None),
-                &PredefinedMenuItem::close_window(None),
-                &PredefinedMenuItem::fullscreen(None),
-                &PredefinedMenuItem::bring_all_to_front(None),
+                &muda::PredefinedMenuItem::minimize(None),
+                &muda::PredefinedMenuItem::maximize(None),
+                &muda::PredefinedMenuItem::close_window(None),
+                &muda::PredefinedMenuItem::fullscreen(None),
+                &muda::PredefinedMenuItem::bring_all_to_front(None),
             ],
         )
         .unwrap();
-        let help_submenu = Submenu::new("&Help", true);
+        let help_submenu = muda::Submenu::new("&Help", true);
 
         // The first item appended always has to be the app (sub)menu (mac will override whatever else is present)
         menu.append_items(&[
@@ -120,9 +120,9 @@ impl MudaMenu {
 
 // Our MenuItems will have id equal to the BindableMessage enum values as a string.
 // For example, the Open file menu item will have id of "OpenFileFinder" (corresponding to BindableMessage::OpenFileFinder)
-pub fn new_menu_item(label: &str, msg: BindableMessage) -> MenuItem {
+pub fn new_menu_item(label: &str, msg: BindableMessage) -> muda::MenuItem {
     let cfg = CONFIG.read().unwrap();
-    let menu_item = MenuItem::with_id(msg.to_string(), label, true, None);
+    let menu_item = muda::MenuItem::with_id(msg.to_string(), label, true, None);
     let keyaccel = keybind_to_keyaccelerator(cfg.get_binding_for_msg(msg).unwrap()).unwrap();
     menu_item.set_key_accelerator(Some(keyaccel)).unwrap();
 
@@ -140,16 +140,16 @@ pub fn keybind_to_keyaccelerator(
 }
 
 // Dummy debug for now (muda doesn't implement debug for some reason?)
-impl fmt::Debug for MudaMenu {
+impl fmt::Debug for Menu {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AppMenu").finish()
     }
 }
 
-pub fn menu_bar_listener() -> impl iced::futures::Stream<Item = AppMessage> {
+pub fn menu_listener() -> impl iced::futures::Stream<Item = AppMessage> {
     iced::stream::channel(100, async |mut sender| {
         loop {
-            if let Ok(event) = MenuEvent::receiver().try_recv() {
+            if let Ok(event) = muda::MenuEvent::receiver().try_recv() {
                 let msg = BindableMessage::from_str((&event.id().0).as_str()).unwrap();
                 let _ = sender.try_send(AppMessage::from(msg));
             } else {

--- a/src/platform_specific/macos.rs
+++ b/src/platform_specific/macos.rs
@@ -1,22 +1,85 @@
 use muda::accelerator::{KeyAccelerator};
 use muda::AcceleratorParseError;
 use crate::CONFIG;
+use crate::common_menu::CommonMenuItem;
 use keybinds2::{Keybind};
 use crate::config::BindableMessage;
 use crate::app::AppMessage;
 use std::fmt;
+use std::path::PathBuf;
 use std::str::FromStr;
+
+pub struct SharedSubmenu {
+    shared_submenus: Vec<muda::Submenu>,
+    recent_files: muda::Submenu,
+}
+impl SharedSubmenu {
+    pub fn new(recent_files: &[PathBuf]) -> Self {
+        let mut shared_submenus: Vec<muda::Submenu> = Vec::new();
+        let common_menu = crate::common_menu::CommonMenu::new();
+        let skeleton = common_menu.skeleton;
+        let recent_files_submenu = muda::Submenu::new("Recent Files", true);
+        for tuple in skeleton {
+            let submenu = muda::Submenu::new(format!("&{}", tuple.0), true);
+            for common_menu_item in tuple.1 {
+                match common_menu_item {
+                    CommonMenuItem::Button(label, msg) => {
+                        submenu.append(&new_menu_item(label.as_str(), msg)).unwrap();
+                    }
+                    CommonMenuItem::RecentFiles => {
+                        for path in recent_files {
+                            let file_name = path
+                                .file_name()
+                                .map(|n| n.to_string_lossy().to_string())
+                                .unwrap_or_else(|| path.to_string_lossy().to_string());
+                            let item = muda::MenuItem::with_id(
+                                path.to_str().unwrap(),
+                                file_name,
+                                true,
+                                None,
+                            );
+                            recent_files_submenu.append(&item).unwrap();
+                        }
+                        submenu.append(&recent_files_submenu).unwrap();
+                    }
+                    CommonMenuItem::Separator => {
+                        submenu
+                            .append(&muda::PredefinedMenuItem::separator())
+                            .unwrap();
+                    }
+                }
+            }
+            shared_submenus.push(submenu);
+        }
+        return Self {
+            shared_submenus: shared_submenus,
+            recent_files: recent_files_submenu,
+        };
+    }
+    pub fn update_recent_files_submenu(&self, recent_files: &[PathBuf]) {
+        for _ in 0..(self.recent_files.items().len()) {
+            self.recent_files.remove_at(0).unwrap();
+        }
+        for path in recent_files {
+            let file_name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| path.to_string_lossy().to_string());
+            let item = muda::MenuItem::with_id(path.to_str().unwrap(), file_name, true, None);
+            self.recent_files.append(&item).unwrap();
+        }
+    }
+}
 
 pub struct Menu {
     menu: muda::Menu,
+    pub shared_menu: SharedSubmenu,
     // These are special in the macos menu bar
     window_submenu: muda::Submenu,
     help_submenu: muda::Submenu,
 }
-// TODO:
-// - Support different languages
 impl Menu {
-    pub fn new() -> Self {
+    pub fn new(recent_files: &[PathBuf]) -> Self {
         let menu = muda::Menu::new();
 
         let app_submenu = muda::Submenu::new("App", true);
@@ -33,50 +96,59 @@ impl Menu {
                 &muda::PredefinedMenuItem::quit(None),
             ])
             .unwrap();
+        // The first item appended always has to be the app (sub)menu (mac will override whatever else is present)
+        menu.append(&app_submenu).unwrap();
+        //////////////////////////////////////////////
+        let shared_menu = SharedSubmenu::new(recent_files);
+        for submenu in &shared_menu.shared_submenus {
+            menu.append(submenu).unwrap();
+        }
 
-        let file_submenu = muda::Submenu::with_items(
-            "&File",
-            true,
-            &[
-                &new_menu_item("Open File", BindableMessage::OpenFileFinder),
-                &new_menu_item("Print PDF", BindableMessage::PrintPdf),
-            ],
-        )
-        .unwrap();
-        let view_submenu = muda::Submenu::with_items(
-            "&View",
-            true,
-            &[
-                &new_menu_item("Toggle UI Dark Mode", BindableMessage::ToggleDarkModeUi),
-                &new_menu_item("Toggle PDF Dark Mode", BindableMessage::ToggleDarkModePdf),
-                &new_menu_item("Toggle Page Borders", BindableMessage::TogglePageBorders),
-                &new_menu_item("Zoom In", BindableMessage::ZoomIn),
-                &new_menu_item("Zoom Out", BindableMessage::ZoomOut),
-                &new_menu_item("Zoom to 100%", BindableMessage::ZoomHome),
-                &new_menu_item("Fit To Screen", BindableMessage::ZoomFit),
-                &new_menu_item("Toggle Sidebar", BindableMessage::ToggleSidebar),
-                &new_menu_item(
-                    "Toggle Presentation Mode",
-                    BindableMessage::TogglePresentationMode,
-                ),
-            ],
-        )
-        .unwrap();
-        let layout_submenu = muda::Submenu::with_items(
-            "&Layout",
-            true,
-            &[
-                &new_menu_item("Toggle Sidebar", BindableMessage::ToggleSidebar),
-                &new_menu_item("Single Page", BindableMessage::SinglePageLayout),
-                &new_menu_item("Double Page", BindableMessage::DoublePageLayout),
-                &new_menu_item(
-                    "Double Page With Title Page",
-                    BindableMessage::DoublePageTitlePageLayout,
-                ),
-                &new_menu_item("Presentation", BindableMessage::PresentationLayout),
-            ],
-        )
-        .unwrap();
+        // let file_submenu = muda::Submenu::with_items(
+        //     "&File",
+        //     true,
+        //     &[
+        //         &new_menu_item("Open File", BindableMessage::OpenFileFinder),
+        //         &new_menu_item("Print PDF", BindableMessage::PrintPdf),
+        //     ],
+        // )
+        // .unwrap();
+        // let view_submenu = muda::Submenu::with_items(
+        //     "&View",
+        //     true,
+        //     &[
+        //         &new_menu_item("Toggle UI Dark Mode", BindableMessage::ToggleDarkModeUi),
+        //         &new_menu_item("Toggle PDF Dark Mode", BindableMessage::ToggleDarkModePdf),
+        //         &new_menu_item("Toggle Page Borders", BindableMessage::TogglePageBorders),
+        //         &new_menu_item("Zoom In", BindableMessage::ZoomIn),
+        //         &new_menu_item("Zoom Out", BindableMessage::ZoomOut),
+        //         &new_menu_item("Zoom to 100%", BindableMessage::ZoomHome),
+        //         &new_menu_item("Fit To Screen", BindableMessage::ZoomFit),
+        //         &new_menu_item("Toggle Sidebar", BindableMessage::ToggleSidebar),
+        //         &new_menu_item(
+        //             "Toggle Presentation Mode",
+        //             BindableMessage::TogglePresentationMode,
+        //         ),
+        //     ],
+        // )
+        // .unwrap();
+        // let layout_submenu = muda::Submenu::with_items(
+        //     "&Layout",
+        //     true,
+        //     &[
+        //         &new_menu_item("Toggle Sidebar", BindableMessage::ToggleSidebar),
+        //         &new_menu_item("Single Page", BindableMessage::SinglePageLayout),
+        //         &new_menu_item("Double Page", BindableMessage::DoublePageLayout),
+        //         &new_menu_item(
+        //             "Double Page With Title Page",
+        //             BindableMessage::DoublePageTitlePageLayout,
+        //         ),
+        //         &new_menu_item("Presentation", BindableMessage::PresentationLayout),
+        //     ],
+        // )
+        // .unwrap();
+
+        //////////////////////////////////////////////
         let window_submenu = muda::Submenu::with_items(
             "&Window",
             true,
@@ -90,19 +162,12 @@ impl Menu {
         )
         .unwrap();
         let help_submenu = muda::Submenu::new("&Help", true);
+        menu.append_items(&[&window_submenu, &help_submenu])
+            .unwrap();
 
-        // The first item appended always has to be the app (sub)menu (mac will override whatever else is present)
-        menu.append_items(&[
-            &app_submenu,
-            &file_submenu,
-            &view_submenu,
-            &layout_submenu,
-            &window_submenu,
-            &help_submenu,
-        ])
-        .unwrap();
         Self {
             menu,
+            shared_menu,
             window_submenu,
             help_submenu,
         }
@@ -150,8 +215,15 @@ pub fn menu_listener() -> impl iced::futures::Stream<Item = AppMessage> {
     iced::stream::channel(100, async |mut sender| {
         loop {
             if let Ok(event) = muda::MenuEvent::receiver().try_recv() {
-                let msg = BindableMessage::from_str((&event.id().0).as_str()).unwrap();
-                let _ = sender.try_send(AppMessage::from(msg));
+                let id = (&event.id().0).as_str();
+                match BindableMessage::from_str(id) {
+                    Ok(msg) => {
+                        let _ = sender.try_send(AppMessage::from(msg));
+                    }
+                    Err(_) => {
+                        let _ = sender.try_send(AppMessage::OpenFile(PathBuf::from(id)));
+                    }
+                }
             } else {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }

--- a/src/platform_specific/mod.rs
+++ b/src/platform_specific/mod.rs
@@ -1,0 +1,24 @@
+use crate::{AppMessage};
+use iced::Subscription;
+use iced::Task;
+
+#[cfg(target_os = "macos")]
+pub mod macos;
+
+pub fn startup_tasks() -> Vec<Task<AppMessage>> {
+    let mut tasks = Vec::new();
+    #[cfg(target_os = "macos")]
+    {
+        tasks.push(Task::done(AppMessage::InitializeMacMenu));
+    }
+    return tasks;
+}
+
+pub fn listeners() -> Vec<Subscription<AppMessage>> {
+    let mut listeners = Vec::new();
+    #[cfg(target_os = "macos")]
+    {
+        listeners.push(Subscription::run(macos::menu_listener));
+    }
+    return listeners;
+}

--- a/src/platform_specific/mod.rs
+++ b/src/platform_specific/mod.rs
@@ -2,7 +2,6 @@ use crate::{AppMessage};
 use iced::Subscription;
 use iced::Task;
 
-#[cfg(target_os = "macos")]
 pub mod macos;
 
 pub fn startup_tasks() -> Vec<Task<AppMessage>> {


### PR DESCRIPTION
Introduces a menu bar with [`muda`](https://crates.io/crates/muda)

I think it's fine to keep the existing menu bar on windows and linux, so this is really only for macos. This should still be tested on windows/linux to see if there's any crashes/bugs/etc. Ideally there would be no difference on those platforms.

Next steps are:
- Finish implementing all the existing buttons to the new menu bar
- Give a configuration option to hide the application menu bar so both don't appear. Generally on mac I would think the app menu bar would be hidden. So there's are also thoughts of giving different builds for different OSes: mac won't have the app menu bar rendered at all, and linux/windows would keep the in-app menu bar. But I'm not sure about this. Thoughts?