### PR TITLE
fix nix build and update the lock file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1760924934,
-        "narHash": "sha256-tuuqY5aU7cUkR71sO2TraVKK2boYrdW3gCSXUkF4i44=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "c6b4d5308293d0d04fcfeee92705017537cad02f",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760934318,
-        "narHash": "sha256-/oUYsC0lUCBory65VK+UHqCCsCspbL1Vgfcf1KUYqVw=",
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "87848bf0cc4f87717fc813a4575f07330c3e743c",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,6 +10,10 @@
   fontconfig,
   pkg-config,
   vulkan-loader,
+  glib,
+  gtk3,
+  pango,
+  xdotool,
   ...
 }: let
   unfilteredRoot = ../.;
@@ -43,11 +47,15 @@
     nativeBuildInputs = [
       pkg-config
       rustPlatform.bindgenHook
+      pango
     ];
 
     buildInputs = [
       fontconfig
       vulkan-loader
+      gtk3
+      glib
+      xdotool
     ];
 
     # prevent bindgen from rebuilding unnecessarily


### PR DESCRIPTION
With introduction of `muda` crate to the codebase, some more system dependencies were required to be installed/available during build.

Can close the PR if cfg gating `muda` to macos is a more preferrable solution and I can make a separate PR for updating the lock file (just in case to keep compatability with potential toolchain/msrv changes, or if newer system deps at some point are required and whatnot)